### PR TITLE
feat(websocket): manage the streaming.myteslamate.com IngressRoute in…

### DIFF
--- a/charts/websocket/templates/ingressroute.yaml
+++ b/charts/websocket/templates/ingressroute.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingressRoute.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "websocket.fullname" . }}-https
+  labels:
+    {{- include "websocket.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    {{- toYaml .Values.ingressRoute.entryPoints | nindent 4 }}
+  routes:
+    - kind: Rule
+      match: Host(`{{ .Values.ingressRoute.host }}`)
+      services:
+        - name: {{ include "websocket.fullname" . }}
+          port: {{ .Values.service.port }}
+  {{- with .Values.ingressRoute.tlsSecretName }}
+  tls:
+    secretName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/websocket/values.yaml
+++ b/charts/websocket/values.yaml
@@ -36,6 +36,15 @@ containerPort: 8081
 service:
   port: 80
 
+# Traefik IngressRoute exposing the forwarder ws externally. Replicates the
+# previously-standalone websocket-node-https route so it's now chart-managed.
+ingressRoute:
+  enabled: true
+  host: streaming.myteslamate.com
+  entryPoints:
+    - websecure
+  tlsSecretName: app-tls
+
 # Elevation enrichment + tuning (see index.js). Empty OPENTOPODATA_URL disables
 # enrichment (frames go out with empty elevation).
 env:


### PR DESCRIPTION
… the chart

Replicates the previously-standalone websocket-node-https route exactly, so ArgoCD adopts it without changing routing.


Claude-Session: https://claude.ai/code/session_0158V8ZAvy4sLVpiv9cRWu2S